### PR TITLE
Fix critical vulnerability in tough-cookie dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "tough-cookie": "4.1.3"
   }
 }


### PR DESCRIPTION
Upgrade tough-cookie from 4.1.2 to 4.1.3 to address prototype pollution vulnerability.

Resolves: TEST-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)